### PR TITLE
[IMP] mqtt_integration: specify clean_session flag

### DIFF
--- a/mqtt_integration/models/mqtt_broker.py
+++ b/mqtt_integration/models/mqtt_broker.py
@@ -17,7 +17,7 @@ class MQTTBroker(models.Model):
         ('ws://', 'WS')], default='mqtt://', string='URI scheme', required=True, tracking=True)
     host = fields.Char(string='Host', default='broker.emqx.io', required=True, tracking=True)
     port = fields.Char(string='Port', default='1883', required=True, tracking=True)
-    client_id = fields.Char(string='Client ID', required=True, readonly=True, copy=False,
+    client_id = fields.Char(string='Client ID', required=True, copy=False,
                            default=lambda self: self._generate_client_id())
     username = fields.Char(string='Username', default='', tracking=True)
     password = fields.Char(string='Password', default='')
@@ -30,6 +30,13 @@ class MQTTBroker(models.Model):
         ('success', 'Success'),
         ('fail', 'Fail'),
     ], string='Connection Status', default='unknown', readonly=True, tracking=True)
+    clean_session = fields.Boolean(
+        string="Clean Session",
+        required=True,
+        default=True,
+        help="Connect as a non-persistent client, meaning Mosquitto will not buffer "
+             "messages while we are disconnected, even at elevated QoS",
+    )
 
     @api.model
     def _generate_client_id(self):

--- a/mqtt_integration/views/mqtt_broker_views.xml
+++ b/mqtt_integration/views/mqtt_broker_views.xml
@@ -36,6 +36,7 @@
                             <field name="url_scheme"/>
                             <field name="host"/>
                             <field name="port"/>
+                            <field name="clean_session"/>
                         </group>
                         <group>
                             <field name="client_id"/>

--- a/mqtt_listener/controllers/listener.py
+++ b/mqtt_listener/controllers/listener.py
@@ -28,6 +28,7 @@ class MQTTListener(threading.Thread):
         self.username = ""
         self.password = ""
         self.topics = [("mqtt/test", 0)]  # Default theme to test
+        self.clean_session = True
         self.is_configured = False  # Configuration status
         
         # Read configuration from the database if available
@@ -56,12 +57,16 @@ class MQTTListener(threading.Thread):
                     self.port = broker_conn.port
                     self.username = broker_conn.username or ""
                     self.password = broker_conn.password or ""
+                    self.clean_session = broker_conn.clean_session
                     self.is_configured = True
                 
                     # Update client_id if available
                     if broker_conn.client_id:
-                        self.client = mqtt.Client(client_id=broker_conn.client_id, 
-                                                callback_api_version=mqtt.CallbackAPIVersion.VERSION2)
+                        self.client = mqtt.Client(
+                            client_id=broker_conn.client_id,
+                            callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
+                            clean_session=self.clean_session,
+                        )
                 
                     # Config username and password
                     if self.username:
@@ -152,9 +157,6 @@ class MQTTListener(threading.Thread):
         
         # Set keepalive lower to detect connection loss faster
         keepalive = 30
-        
-        # Set clean_session=True to avoid storing old messages
-        self.client.clean_session = True
 
         # Check if the configuration is valid
         if not self.broker or int(self.port) <= 0:


### PR DESCRIPTION
Add the option to specify the clean_session flag.  This allows the user to elevate the QoS setting on a subscribe client.